### PR TITLE
Correction de l'encodage

### DIFF
--- a/contenu/messages.txt
+++ b/contenu/messages.txt
@@ -1,1 +1,1 @@
-Rabais étudiant instantané sous présentation de la carte étudiante mise à jour!
+Rabais Ã©tudiant instantanÃ© sous prÃ©sentation de la carte Ã©tudiante mise Ã  jour!


### PR DESCRIPTION
L'encodage du fichier des message n'était pas en UTF-8, ce qui empêche le fichier de s'afficher correctement dans le navigateur.